### PR TITLE
Backport of CF Clearance reuse fix

### DIFF
--- a/RuriLib/Blocks/BlockBypassCF.cs
+++ b/RuriLib/Blocks/BlockBypassCF.cs
@@ -75,9 +75,10 @@ namespace RuriLib
             // If the clearance info is already set and we're not getting it fresh each time, skip
             if (data.UseProxies)
             {
-                if (data.Proxy.Clearance != "" && data.Proxy.Cfduid != "" && !data.GlobalSettings.Proxies.AlwaysGetClearance)
+                if (data.Proxy.Clearance != "" && !data.GlobalSettings.Proxies.AlwaysGetClearance)
                 {
                     data.Log(new LogEntry("Skipping CF Bypass because there is already a valid cookie", Colors.White));
+                    data.Cookies.Add("cf_clearance", data.Proxy.Clearance);
                     return;
                 }
             }


### PR DESCRIPTION
Readding this fix to leaf.xnet cf bypass:
https://github.com/openbullet/openbullet/commit/fce32f685ce81bbca027984615d2b41d6a84b853#diff-d9125531b761ec8678f86b718b47c428