### PR TITLE
Fix JSON Parsing using JToken

### DIFF
--- a/RuriLib/Functions/Parsing/Parse.cs
+++ b/RuriLib/Functions/Parsing/Parse.cs
@@ -211,12 +211,12 @@ namespace RuriLib.Utils.Parsing
                     if (input.Trim().StartsWith("["))
                     {
                         JArray json = JArray.Parse(input);
-                        list.Add(json.SelectToken(field, false).ToString());
+                        list.Add(json.SelectToken(field, false).First().ToString());
                     }
                     else
                     {
                         JObject json = JObject.Parse(input);
-                        list.Add(json.SelectTokens(field, false).ToString());
+                        list.Add(json.SelectTokens(field, false).First().ToString());
                     }
                 }
             }


### PR DESCRIPTION
Current SelectTokens method returns an IEnumerable, trying to display it with ToString results in:

`Newtonsoft.Json.Linq.JsonPath.FieldFilter+<ExecuteFilter>`

Fetching the first item, however, can display its value.