### PR TITLE
Change bot behavior on custom status

### DIFF
--- a/OpenBullet/Views/Main/Configs/OtherOptions/General.xaml
+++ b/OpenBullet/Views/Main/Configs/OtherOptions/General.xaml
@@ -25,6 +25,7 @@
                 <Label Content="Maximum CPM to avoid overloading the website (0 = infinite)" />
                 <xctk:IntegerUpDown Background="Transparent" Width="100" Margin="10 0 0 0" Value="{Binding MaxCPM}" Foreground="{DynamicResource ForegroundMain}" HorizontalAlignment="Left" Minimum="0" Maximum="100000"/>
             </DockPanel>
+            <CheckBox Content="Force Run After CUSTOM Status" IsChecked="{Binding ForceRunCustomStatus}" VerticalContentAlignment="Center"/>
         </StackPanel>
     </Grid>
 </Page>

--- a/RuriLib/LoliScript/LoliScript.cs
+++ b/RuriLib/LoliScript/LoliScript.cs
@@ -215,13 +215,24 @@ namespace RuriLib.LS
             // Clean the inner Log
             data.LogBuffer.Clear();
 
-            if (data.Status != BotStatus.NONE && data.Status != BotStatus.SUCCESS)
+            if (!data.ConfigSettings.ForceRunCustomStatus)
             {
-                i = lines.Count(); // Go to the end
-                return;
+                if (data.Status != BotStatus.NONE && data.Status != BotStatus.SUCCESS)
+                {
+                    i = lines.Count(); // Go to the end
+                    return;
+                }
+            }
+            else
+            {
+                if (data.Status != BotStatus.NONE && data.Status != BotStatus.SUCCESS && data.Status != BotStatus.CUSTOM)
+                {
+                    i = lines.Count(); // Go to the end
+                    return;
+                }
             }
 
-            TAKELINE:
+        TAKELINE:
 
             CurrentLine = lines[i];
 

--- a/RuriLib/Models/ConfigSettings.cs
+++ b/RuriLib/Models/ConfigSettings.cs
@@ -50,6 +50,10 @@ namespace RuriLib
         private int _maxRedirects = 8;
         /// <summary>The maximum amount of times we can be redirected to different URLs for a single request.</summary>
         public int MaxRedirects { get { return _maxRedirects; } set { _maxRedirects = value; OnPropertyChanged(); } }
+
+        private bool forceRunCustomStatus = false;
+        /// <summary>If the Bot should run after CUSTOM status</summary>
+        public bool ForceRunCustomStatus { get { return forceRunCustomStatus; } set { forceRunCustomStatus = value; OnPropertyChanged(); } }
         #endregion
 
         #region Proxy


### PR DESCRIPTION
created a checkbox in config manager -> other options -> general
![image](https://user-images.githubusercontent.com/53093696/75882429-73536b80-5e21-11ea-9d92-ec5b3e45e61c.png)
if checked the bot wont skip to the end on custom status it will run through all blocks
you should change the name tho could not find a fitting name for it :D
closes #507 