### PR TITLE
Added support to specify the format string in UnixTimeToDate

### DIFF
--- a/OpenBullet/LSDoc.xml
+++ b/OpenBullet/LSDoc.xml
@@ -237,6 +237,7 @@ FUNCTION Translate StopAfterFirstMatch=True
   KEY "key2" VALUE "value2"
   "input" -> CAP "Translated"
 FUNCTION DateToUnixTime "format" "input" -> VAR "DATE"
+FUNCTION UnixTimeToDate "format" "input" -> VAR "UNIXTIME"
 FUNCTION Replace "what" "with" UseRegex=True "input" -> VAR "REPLACED"
 FUNCTION RegexMatch "pattern" "input" -> VAR "MATCHED"
 FUNCTION RandomNum "0" "100" -> VAR "RANDOM"

--- a/OpenBullet/Views/StackerBlocks/PageBlockFunction.xaml
+++ b/OpenBullet/Views/StackerBlocks/PageBlockFunction.xaml
@@ -236,6 +236,18 @@
                     </DockPanel>
                 </StackPanel>
             </TabItem>
+            <TabItem x:Name="unixTimeToDateTab">
+                <StackPanel>
+                    <DockPanel>
+                        <Label Content="Date Format:"/>
+                        <TextBox Text="{Binding DateFormat, UpdateSourceTrigger=PropertyChanged}">
+                            <TextBox.ToolTip>
+                                <TextBlock>Key characters:<LineBreak/>y: year<LineBreak/>M: month<LineBreak/>d: day<LineBreak/>H: hour<LineBreak/>m: minute<LineBreak/>s: second</TextBlock>
+                            </TextBox.ToolTip>
+                        </TextBox>
+                    </DockPanel>
+                </StackPanel>
+            </TabItem>
         </TabControl>
 
         <TextBlock Grid.Row="2" x:Name="functionInfoTextblock" TextWrapping="WrapWithOverflow" Foreground="{DynamicResource ForegroundMain}" HorizontalAlignment="Center" VerticalAlignment="Center"/>

--- a/OpenBullet/Views/StackerBlocks/PageBlockFunction.xaml.cs
+++ b/OpenBullet/Views/StackerBlocks/PageBlockFunction.xaml.cs
@@ -136,6 +136,10 @@ namespace OpenBullet.Views.StackerBlocks
                 case BlockFunction.Function.PBKDF2PKCS5:
                     functionTabControl.SelectedIndex = 15;
                     break;
+
+                case BlockFunction.Function.UnixTimeToDate:
+                    functionTabControl.SelectedIndex = 16;
+                    break;
             }
         }
 

--- a/RuriLib/Blocks/BlockFunction.cs
+++ b/RuriLib/Blocks/BlockFunction.cs
@@ -375,6 +375,16 @@ namespace RuriLib
                     DateFormat = LineParser.ParseLiteral(ref input, "DATE FORMAT");
                     break;
 
+                case Function.UnixTimeToDate:
+                    DateFormat = LineParser.ParseLiteral(ref input, "DATE FORMAT");
+                    // a little backward compatability with the old line format.
+                    if (LineParser.Lookahead(ref input) != TokenType.Literal)
+                    {
+                        InputString = DateFormat;
+                        DateFormat = "yyyy-MM-dd:HH-mm-ss";
+                    }
+                    break;
+
                 case Function.Replace:
                     ReplaceWhat = LineParser.ParseLiteral(ref input, "What");
                     ReplaceWith = LineParser.ParseLiteral(ref input, "With");
@@ -525,7 +535,12 @@ namespace RuriLib
 
                 case Function.DateToUnixTime:
                     writer
-                        .Literal(DateFormat, "DateFormat");
+                        .Literal(DateFormat, "DateFormat", true);
+                    break;
+
+                case Function.UnixTimeToDate:
+                    writer
+                        .Literal(DateFormat, "DateFormat", true);
                     break;
 
                 case Function.Replace:
@@ -718,7 +733,7 @@ namespace RuriLib
                         break;
 
                     case Function.UnixTimeToDate:
-                        outputString = double.Parse(localInputString).ToDateTime().ToShortDateString();
+                        outputString = double.Parse(localInputString).ToDateTime().ToString(dateFormat);
                         break;
 
                     case Function.CurrentUnixTime:

--- a/RuriLib/LoliScript/Writer/BlockWriter.cs
+++ b/RuriLib/LoliScript/Writer/BlockWriter.cs
@@ -63,10 +63,11 @@ namespace RuriLib.LS
         /// </summary>
         /// <param name="literal">The literal value to write</param>
         /// <param name="property">The name of the property of the block. If the value is the default one, it will not be written. Do not set this parameter to always write the variable.</param>
+        /// <param name="alwaysWrite">Always write the value even if that value is default</param>
         /// <returns>The BlockWriter itself</returns>
-        public BlockWriter Literal(string literal, string property = "")
+        public BlockWriter Literal(string literal, string property = "", bool alwaysWrite = false)
         {
-            if (property != string.Empty && CheckDefault(literal, property)) return this;
+            if (property != string.Empty && (!alwaysWrite && CheckDefault(literal, property))) return this;
             Write($"\"{literal.Replace("\\", "\\\\").Replace("\"", "\\\"")}\" ");
             return this;
         }        


### PR DESCRIPTION
(Probably makes UnixTimeToISO8601 deprecated?)
inadvertently found and fixed a bug where saving some default values is required.