### PR TITLE
Added option for HMAC keys to be base64 encoded.

### DIFF
--- a/OpenBullet/LSDoc.xml
+++ b/OpenBullet/LSDoc.xml
@@ -231,7 +231,7 @@ FUNCTION ClearCookies
 
 Peculiar functions:
 FUNCTION Hash SHA512 "&lt;PASS&gt;" -> VAR "HASHED"
-FUNCTION HMAC SHA1 "key" HmacBase64=True "&lt;PASS&gt;" -> VAR "DIGEST"
+FUNCTION HMAC SHA1 "key" HmacBase64=True KeyBase64=False "&lt;PASS&gt;" -> VAR "DIGEST"
 FUNCTION Translate StopAfterFirstMatch=True
   KEY "key1" VALUE "value1"
   KEY "key2" VALUE "value2"

--- a/OpenBullet/Views/StackerBlocks/PageBlockFunction.xaml
+++ b/OpenBullet/Views/StackerBlocks/PageBlockFunction.xaml
@@ -61,6 +61,7 @@
                         <Label Content="HMAC Key:"/>
                         <TextBox Text="{Binding HmacKey, UpdateSourceTrigger=PropertyChanged}"/>
                     </DockPanel>
+                    <CheckBox VerticalContentAlignment="Center" Content="HMAC Key Base64" IsChecked="{Binding KeyBase64}" ToolTip="Whether HMAC Key uses base64 encoding instead of ascii"/>
                     <CheckBox VerticalContentAlignment="Center" Content="Output Base64" IsChecked="{Binding HmacBase64}" ToolTip="Whether to output with base64 encoding instead of hex encoding"/>
                 </StackPanel>
             </TabItem>

--- a/RuriLib/Blocks/BlockFunction.cs
+++ b/RuriLib/Blocks/BlockFunction.cs
@@ -912,22 +912,28 @@ namespace RuriLib
         /// <returns>The HMAC signature</returns>
         public static string Hmac(string baseString, Hash type, string key, bool base64, bool keyBase64)
         {
+            byte[] keybytes;
+            if (keyBase64)
+                keybytes = Convert.FromBase64String(key);
+            else
+                keybytes = Encoding.ASCII.GetBytes(key);
+
             switch (type)
             {
                 case Hash.MD5:
-                    return Crypto.HMACMD5(baseString, key, base64, keyBase64);
+                    return Crypto.HMACMD5(baseString, keybytes, base64);
 
                 case Hash.SHA1:
-                    return Crypto.HMACSHA1(baseString, key, base64, keyBase64);
+                    return Crypto.HMACSHA1(baseString, keybytes, base64);
 
                 case Hash.SHA256:
-                    return Crypto.HMACSHA256(baseString, key, base64, keyBase64);
+                    return Crypto.HMACSHA256(baseString, keybytes, base64);
 
                 case Hash.SHA384:
-                    return Crypto.HMACSHA384(baseString, key, base64, keyBase64);
+                    return Crypto.HMACSHA384(baseString, keybytes, base64);
 
                 case Hash.SHA512:
-                    return Crypto.HMACSHA512(baseString, key, base64, keyBase64);
+                    return Crypto.HMACSHA512(baseString, keybytes, base64);
 
                 default:
                     throw new NotSupportedException("Unsupported algorithm");

--- a/RuriLib/Blocks/BlockFunction.cs
+++ b/RuriLib/Blocks/BlockFunction.cs
@@ -178,6 +178,10 @@ namespace RuriLib
         /// <summary>Whether to output the message as a base64-encoded string instead of a hex-encoded string.</summary>
         public bool HmacBase64 { get { return hmacBase64; } set { hmacBase64 = value; OnPropertyChanged(); } }
 
+        private bool keyBase64 = false;
+        /// <summary>Whether the HMAC Key is a base64-encoded string instead of ascii.</summary>
+        public bool KeyBase64 { get { return keyBase64; } set { keyBase64 = value; OnPropertyChanged(); } }
+
         // -- Translate
         private bool stopAfterFirstMatch = true;
         /// <summary>Whether to stop translating after the first match.</summary>
@@ -515,7 +519,8 @@ namespace RuriLib
                     writer
                         .Token(HashType)
                         .Literal(HmacKey)
-                        .Boolean(HmacBase64, "HmacBase64");
+                        .Boolean(HmacBase64, "HmacBase64")
+                        .Boolean(KeyBase64, "KeyBase64");
                     break;
 
                 case Function.Translate:
@@ -677,7 +682,7 @@ namespace RuriLib
                         break;
 
                     case Function.HMAC:
-                        outputString = Hmac(localInputString, hashType, ReplaceValues(hmacKey, data), hmacBase64);
+                        outputString = Hmac(localInputString, hashType, ReplaceValues(hmacKey, data), hmacBase64, keyBase64);
                         break;
 
                     case Function.Translate:
@@ -903,25 +908,26 @@ namespace RuriLib
         /// <param name="type">The hashing function</param>
         /// <param name="key">The HMAC key</param>
         /// <param name="base64">Whether the output should be encrypted as a base64 string</param>
+        /// <param name="keyBase64"></param>
         /// <returns>The HMAC signature</returns>
-        public static string Hmac(string baseString, Hash type, string key, bool base64)
+        public static string Hmac(string baseString, Hash type, string key, bool base64, bool keyBase64)
         {
             switch (type)
             {
                 case Hash.MD5:
-                    return Crypto.HMACMD5(baseString, key, base64);
+                    return Crypto.HMACMD5(baseString, key, base64, keyBase64);
 
                 case Hash.SHA1:
-                    return Crypto.HMACSHA1(baseString, key, base64);
+                    return Crypto.HMACSHA1(baseString, key, base64, keyBase64);
 
                 case Hash.SHA256:
-                    return Crypto.HMACSHA256(baseString, key, base64);
+                    return Crypto.HMACSHA256(baseString, key, base64, keyBase64);
 
                 case Hash.SHA384:
-                    return Crypto.HMACSHA384(baseString, key, base64);
+                    return Crypto.HMACSHA384(baseString, key, base64, keyBase64);
 
                 case Hash.SHA512:
-                    return Crypto.HMACSHA512(baseString, key, base64);
+                    return Crypto.HMACSHA512(baseString, key, base64, keyBase64);
 
                 default:
                     throw new NotSupportedException("Unsupported algorithm");

--- a/RuriLib/Functions/Crypto/Crypto.cs
+++ b/RuriLib/Functions/Crypto/Crypto.cs
@@ -67,11 +67,17 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
+        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACMD5(string input, string key, bool base64)
+        public static string HMACMD5(string input, string key, bool base64, bool keyBase64)
         {
-            HMACMD5 hmac = new HMACMD5(System.Text.Encoding.ASCII.GetBytes(key));
-            var hash = hmac.ComputeHash(System.Text.Encoding.ASCII.GetBytes(input));
+            HMACMD5 hmac;
+            if (keyBase64)
+                hmac = new HMACMD5(Convert.FromBase64String(key));
+            else
+                hmac = new HMACMD5(Encoding.ASCII.GetBytes(key));
+
+            var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
         }
@@ -95,11 +101,17 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
+        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACSHA1(string input, string key, bool base64)
+        public static string HMACSHA1(string input, string key, bool base64, bool keyBase64)
         {
-            HMACSHA1 hmac = new HMACSHA1(System.Text.Encoding.ASCII.GetBytes(key));
-            var hash = hmac.ComputeHash(System.Text.Encoding.ASCII.GetBytes(input));
+            HMACSHA1 hmac;
+            if (keyBase64)
+                hmac = new HMACSHA1(Convert.FromBase64String(key));
+            else
+                hmac = new HMACSHA1(Encoding.ASCII.GetBytes(key));
+
+            var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
         }
@@ -123,11 +135,17 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
+        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACSHA256(string input, string key, bool base64)
+        public static string HMACSHA256(string input, string key, bool base64, bool keyBase64)
         {
-            HMACSHA256 hmac = new HMACSHA256(System.Text.Encoding.ASCII.GetBytes(key));
-            var hash = hmac.ComputeHash(System.Text.Encoding.ASCII.GetBytes(input));
+            HMACSHA256 hmac;
+            if (keyBase64)
+                hmac = new HMACSHA256(Convert.FromBase64String(key));
+            else
+                hmac = new HMACSHA256(Encoding.ASCII.GetBytes(key));
+
+            var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
         }
@@ -151,11 +169,17 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
+        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACSHA384(string input, string key, bool base64)
+        public static string HMACSHA384(string input, string key, bool base64, bool keyBase64)
         {
-            HMACSHA384 hmac = new HMACSHA384(System.Text.Encoding.ASCII.GetBytes(key));
-            var hash = hmac.ComputeHash(System.Text.Encoding.ASCII.GetBytes(input));
+            HMACSHA384 hmac;
+            if (keyBase64)
+                hmac = new HMACSHA384(Convert.FromBase64String(key));
+            else
+                hmac = new HMACSHA384(Encoding.ASCII.GetBytes(key));
+
+            var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
         }
@@ -179,11 +203,17 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
+        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACSHA512(string input, string key, bool base64)
+        public static string HMACSHA512(string input, string key, bool base64, bool keyBase64)
         {
-            HMACSHA512 hmac = new HMACSHA512(System.Text.Encoding.ASCII.GetBytes(key));
-            var hash = hmac.ComputeHash(System.Text.Encoding.ASCII.GetBytes(input));
+            HMACSHA512 hmac;
+            if (keyBase64)
+                hmac = new HMACSHA512(Convert.FromBase64String(key));
+            else
+                hmac = new HMACSHA512(Encoding.ASCII.GetBytes(key));
+
+            var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
         }

--- a/RuriLib/Functions/Crypto/Crypto.cs
+++ b/RuriLib/Functions/Crypto/Crypto.cs
@@ -67,16 +67,10 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
-        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACMD5(string input, string key, bool base64, bool keyBase64)
+        public static string HMACMD5(string input, byte[] key, bool base64)
         {
-            HMACMD5 hmac;
-            if (keyBase64)
-                hmac = new HMACMD5(Convert.FromBase64String(key));
-            else
-                hmac = new HMACMD5(Encoding.ASCII.GetBytes(key));
-
+            HMACMD5 hmac = new HMACMD5(key);
             var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
@@ -101,16 +95,10 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
-        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACSHA1(string input, string key, bool base64, bool keyBase64)
+        public static string HMACSHA1(string input, byte[] key, bool base64)
         {
-            HMACSHA1 hmac;
-            if (keyBase64)
-                hmac = new HMACSHA1(Convert.FromBase64String(key));
-            else
-                hmac = new HMACSHA1(Encoding.ASCII.GetBytes(key));
-
+            HMACSHA1 hmac = new HMACSHA1(key);
             var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
@@ -135,16 +123,10 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
-        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACSHA256(string input, string key, bool base64, bool keyBase64)
+        public static string HMACSHA256(string input, byte[] key, bool base64)
         {
-            HMACSHA256 hmac;
-            if (keyBase64)
-                hmac = new HMACSHA256(Convert.FromBase64String(key));
-            else
-                hmac = new HMACSHA256(Encoding.ASCII.GetBytes(key));
-
+            HMACSHA256 hmac = new HMACSHA256(key);
             var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
@@ -169,16 +151,10 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
-        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACSHA384(string input, string key, bool base64, bool keyBase64)
+        public static string HMACSHA384(string input, byte[] key, bool base64)
         {
-            HMACSHA384 hmac;
-            if (keyBase64)
-                hmac = new HMACSHA384(Convert.FromBase64String(key));
-            else
-                hmac = new HMACSHA384(Encoding.ASCII.GetBytes(key));
-
+            HMACSHA384 hmac = new HMACSHA384(key);
             var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }
@@ -203,16 +179,10 @@ namespace RuriLib.Functions.Crypto
         /// <param name="input">The message for which a signature will be generated</param>
         /// <param name="key">The secret key to use to sign the message</param>
         /// <param name="base64">Whether to return the string as Base64 or as a Hex</param>
-        /// <param name="keyBase64">Whether key is base64 encoded</param>
         /// <returns>A base64 or uppercase hex string.</returns>
-        public static string HMACSHA512(string input, string key, bool base64, bool keyBase64)
+        public static string HMACSHA512(string input, byte[] key, bool base64)
         {
-            HMACSHA512 hmac;
-            if (keyBase64)
-                hmac = new HMACSHA512(Convert.FromBase64String(key));
-            else
-                hmac = new HMACSHA512(Encoding.ASCII.GetBytes(key));
-
+            HMACSHA512 hmac = new HMACSHA512(key);
             var hash = hmac.ComputeHash(Encoding.ASCII.GetBytes(input));
             if (base64) { return Convert.ToBase64String(hash); }
             else { return ToHex(hash); }


### PR DESCRIPTION
[hmacTest.zip](https://github.com/openbullet/openbullet/files/4390614/hmacTest.zip)
Test file used