### PR TITLE
fixed typo in default code from Execute JS block

### DIFF
--- a/RuriLib/Blocks/SBlockExecuteJS.cs
+++ b/RuriLib/Blocks/SBlockExecuteJS.cs
@@ -10,7 +10,7 @@ namespace RuriLib
     /// </summary>
     public class SBlockExecuteJS : BlockBase
     {
-        private string javascriptCode = "alert('henlo');";
+        private string javascriptCode = "alert('hello');";
         /// <summary>The javascript code.</summary>
         public string JavascriptCode { get { return javascriptCode; } set { javascriptCode = value; OnPropertyChanged(); } }
 


### PR DESCRIPTION
Just a fix for a small typo in RuriLib/Blocks/SBlockExecute.js